### PR TITLE
IMPROVEMENT: Add `completeSlideAt` param

### DIFF
--- a/lib/src/slidable_button.dart
+++ b/lib/src/slidable_button.dart
@@ -230,33 +230,38 @@ class _SlidableButtonState extends State<SlidableButton>
 
   void _onDragEnd(DragEndDetails details) {
     final extent = _container!.size.width - _positioned!.size.width;
-    var fractionalVelocity = (details.primaryVelocity! / extent).abs();
+    double fractionalVelocity = (details.primaryVelocity! / extent).abs();
     if (fractionalVelocity < 0.5) {
       fractionalVelocity = 0.5;
     }
-    SlidableButtonPosition result;
+
     double acceleration, velocity;
     if (_controller.value >= widget.completeSlideAt) {
       acceleration = 0.5;
       velocity = fractionalVelocity;
-      result = SlidableButtonPosition.right;
     } else {
       acceleration = -0.5;
       velocity = -fractionalVelocity;
-      result = SlidableButtonPosition.left;
     }
+
     final simulation = SlidableSimulation(
       acceleration,
       _controller.value,
       1.0,
       velocity,
     );
+
     _controller.animateWith(simulation).whenComplete(() {
-      if (widget.onChanged != null) {
-        widget.onChanged!(result);
-      }
+      SlidableButtonPosition result = _controller.value == 0
+          ? SlidableButtonPosition.left
+          : SlidableButtonPosition.right;
+
       if (widget.isRestart && widget.initialPosition != result) {
         _initialPositionController();
+      }
+
+      if (widget.onChanged != null) {
+        widget.onChanged!(result);
       }
     });
   }

--- a/lib/src/slidable_button.dart
+++ b/lib/src/slidable_button.dart
@@ -57,6 +57,11 @@ class SlidableButton extends StatefulWidget {
   /// Initial button position. It can on the left or right.
   final SlidableButtonPosition initialPosition;
 
+  /// The % at which the slide gesture should be considered as completed (0 to 1)
+  ///
+  /// Default value is 0.5.
+  final double completeSlideAt;
+
   /// Listen to position, is button on the left or right.
   ///
   /// You must set this argument although is null.
@@ -83,6 +88,7 @@ class SlidableButton extends StatefulWidget {
       this.border,
       this.borderRadius = const BorderRadius.all(Radius.circular(60.0)),
       this.initialPosition = SlidableButtonPosition.left,
+      this.completeSlideAt = 0.5,
       this.height = 36.0,
       this.width = 120.0,
       this.buttonWidth,
@@ -230,7 +236,7 @@ class _SlidableButtonState extends State<SlidableButton>
     }
     SlidableButtonPosition result;
     double acceleration, velocity;
-    if (_controller.value >= 0.5) {
+    if (_controller.value >= widget.completeSlideAt) {
       acceleration = 0.5;
       velocity = fractionalVelocity;
       result = SlidableButtonPosition.right;


### PR DESCRIPTION
Completes the slide action after `completeSlideAt` % of the button is slided.

**Before:**

```dart
SlideButton(
  ...
  // completeSlideAt: 0.5,
  ...
),
```
https://user-images.githubusercontent.com/8232573/153711260-419c4fb7-2417-4b71-92dd-55bb4e12d7d8.mov

**After:**

```dart
SlideButton(
  ...
  completeSlideAt: 1,
  ...
),
```

https://user-images.githubusercontent.com/8232573/153711256-6d097b0b-ea4d-417d-93dd-253e92f29c6b.mov

